### PR TITLE
Update actions/setup-node and softprops/action-gh-release as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Shared Github Actions for ioBroker testing workflows: Deploy step
 | `build`           | Set to `'true'` when the adapter needs a build step before testing                                                                                                                                   | ❌        |      `false`      |
 | `build-command`   | Overwrite the default build command                                                                                                                                                                  | ❌        | `'npm run build'` |
 | `npm-token`       | The token to use to publish to npm                                                                                                                                                                   | ✔         |         -         |
-| `github-token`    | The token to use to create a GitHub release                                                                                                                                                          | ✔         |         -         |
+| `github-token`    | The token to use to create a GitHub release                                                                                                                                                          | ❌         |         -         |
 
 If Sentry integration is desired, the following inputs are used to configure it:
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: true
   github-token:
     description: "The token to use to create a GitHub release"
-    required: true
+    default: ""
 
   sentry:
     description: "Enable Sentry releases integration"
@@ -103,6 +103,7 @@ runs:
         npm publish ${{ steps.extract_release.outputs.TAG }}
 
     - name: Create Github Release
+      if: ${{ inputs.github-token != '' }}
       uses: softprops/action-gh-release@master
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "ioBroker Testing: Deploy"
 author: "AlCalzone"
-#description: 'Greet someone'
+description: "Publish the adapter to npm and create a GitHub release"
 
 inputs:
   node-version:
@@ -14,7 +14,7 @@ inputs:
     default: 'npm'
   build:
     description: "Set to true when the adapter needs a build step"
-    default: false
+    default: "false"
   build-command:
     description: "Overwrite the default build command"
     default: "npm run build"
@@ -27,10 +27,10 @@ inputs:
 
   sentry:
     description: "Enable Sentry releases integration"
-    default: false
+    default: "false"
   sentry-token:
     description: "The token to use to create a Sentry release"
-    default: false
+    default: "false"
   sentry-url:
     description: "Under which URL the Sentry instance is running"
     default: "https://sentry.iobroker.net"
@@ -39,16 +39,16 @@ inputs:
     default: "iobroker"
   sentry-project:
     description: "The project name on Sentry"
-    default: false
+    default: "false"
   sentry-version-prefix:
     description: "The prefix for release versions on Sentry"
-    default: false
+    default: "false"
   sentry-github-integration:
     description: "Set to true once Github integration is set up in Sentry"
-    default: false
+    default: "false"
   sentry-sourcemap-paths:
     description: "If sourcemaps should be uploaded to Sentry, specify their path here"
-    default: false
+    default: "false"
 
 # Conditional syntax isn't supported, but there are workarounds:
 # https://github.com/actions/runner/issues/834#issuecomment-909921245
@@ -60,7 +60,7 @@ runs:
       uses: actions/checkout@v4
 
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ (inputs.package-cache != 'false' && inputs.package-cache != '') && inputs.package-cache || '' }}
@@ -103,7 +103,7 @@ runs:
         npm publish ${{ steps.extract_release.outputs.TAG }}
 
     - name: Create Github Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@master
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       with:


### PR DESCRIPTION
I forked all three adapter workflow actions to update the `actions/checkout` and `actions/setup-node`. In this case you already updated the `actions/checkout` in the meantime.

I also updated the `softprops/action-gh-release` action to use the master branch, because the most recent release (v1) uses an outdated node version, which also causes warnings in 'enduser workflow actions'. This was fixed with the latest commit on softprops/action-gh-release master branch.

VSCode marked the missing description as error and told me that input defaults must be strings, so I changed theses things as well.

Not sure if you want to merge this, but I didn't want to withhold it...